### PR TITLE
Hott 1694 query params supports

### DIFF
--- a/flaskr/__init__.py
+++ b/flaskr/__init__.py
@@ -1,6 +1,6 @@
 import os
 
-from flask import Flask
+from flask import Flask, request
 
 from flaskr import tokenizer
 from flaskr import spelling_corrector
@@ -30,11 +30,15 @@ def create_app(test_config=None):
 
     api_prefix = "/api/search/"
 
-    @app.route(f"{api_prefix}/tokens/<string:term>", methods=["GET"])
-    def tokens(term):
-        entities = tokenizer.get_entities(term)
+    @app.route(f"{api_prefix}/tokens", methods=["GET"])
+    def tokens():
+        term = request.args.get("q", default="", type=str)
 
-        return {"entities": entities}
+        if term == "":
+            return "Error: the query params is empty.", 400
+        else:
+            entities = tokenizer.get_entities(term)
+            return {"entities": entities}
 
     @app.route(f"{api_prefix}/healthcheck", methods=["GET"])
     def healthcheck():

--- a/flaskr/__init__.py
+++ b/flaskr/__init__.py
@@ -40,6 +40,19 @@ def create_app(test_config=None):
             entities = tokenizer.get_entities(term)
             return {"entities": entities}
 
+    @app.route(f"{api_prefix}/correct-terms", methods=["GET"])
+    def correct_terms():
+        term = request.args.get("q", default="", type=str)
+
+        if term == "":
+            return "Error: the query params is empty.", 400
+        else:
+            corrected_terms = spell_corr.correct(term)
+
+            return {
+                "entities": {"correct_terms": corrected_terms, "original_terms": term}
+            }
+
     @app.route(f"{api_prefix}/healthcheck", methods=["GET"])
     def healthcheck():
         tokens = tokenizer.get_entities("tall man")["tokens"]["all"]
@@ -51,13 +64,5 @@ def create_app(test_config=None):
         healthcheck["healthy"] = healthy
 
         return healthcheck
-
-    @app.route(f"{api_prefix}/correct-terms/<string:term>", methods=["GET"])
-    def correct_terms(term):
-        corrected_terms = spell_corr.correct(term)
-
-        return {
-            "entities": {"correct_terms": corrected_terms, "original_terms": term},
-        }
 
     return app

--- a/flaskr/__init__.py
+++ b/flaskr/__init__.py
@@ -36,9 +36,9 @@ def create_app(test_config=None):
 
         if term == "":
             return "Error: the query params is empty.", 400
-        else:
-            entities = tokenizer.get_entities(term)
-            return {"entities": entities}
+
+        entities = tokenizer.get_entities(term)
+        return {"entities": entities}
 
     @app.route(f"{api_prefix}/correct-terms", methods=["GET"])
     def correct_terms():
@@ -46,12 +46,10 @@ def create_app(test_config=None):
 
         if term == "":
             return "Error: the query params is empty.", 400
-        else:
-            corrected_terms = spell_corr.correct(term)
 
-            return {
-                "entities": {"correct_terms": corrected_terms, "original_terms": term}
-            }
+        corrected_terms = spell_corr.correct(term)
+
+        return {"entities": {"correct_terms": corrected_terms, "original_terms": term}}
 
     @app.route(f"{api_prefix}/healthcheck", methods=["GET"])
     def healthcheck():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,9 @@ from flaskr import create_app
 def app():
     app = create_app()
     app.config.update(
-        {"TESTING": True,}
+        {
+            "TESTING": True,
+        }
     )
 
     f = open("REVISION", "a")

--- a/tests/functional/test_get_tokens.py
+++ b/tests/functional/test_get_tokens.py
@@ -1,15 +1,15 @@
-# Test GET /tokens/<term>
+# Test GET /tokens?q=query+terms
 
 
 def test_get_tokens_returns_success(client):
-    response = client.get("/api/search/tokens/red car")
+    response = client.get("/api/search/tokens?q=query+terms")
 
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "application/json"
 
 
 def test_get_tokens_returns_valid_json(client):
-    response = client.get("/api/search/tokens/red car")
+    response = client.get("/api/search/tokens?q=query+terms")
 
     response_body = response.json
 
@@ -17,3 +17,12 @@ def test_get_tokens_returns_valid_json(client):
 
     for token_type in ["all", "adjectives", "nouns", "verbs"]:
         assert token_type in response_body["entities"]["tokens"]
+
+
+# When query is empty
+def test_get_tokens_returns_400_when_query_is_(client):
+    query = ""
+    response = client.get(f"/api/search/tokens?q={query}")
+
+    assert response.status_code == 400
+    assert response.text == "Error: the query params is empty."

--- a/tests/functional/test_get_tokens.py
+++ b/tests/functional/test_get_tokens.py
@@ -20,7 +20,7 @@ def test_get_tokens_returns_valid_json(client):
 
 
 # When query is empty
-def test_get_tokens_returns_400_when_query_is_(client):
+def test_get_tokens_returns_400(client):
     query = ""
     response = client.get(f"/api/search/tokens?q={query}")
 

--- a/tests/functional/test_spelling_corrector.py
+++ b/tests/functional/test_spelling_corrector.py
@@ -1,19 +1,17 @@
-# Test GET /correct-terms/<term>
+# Test GET /correct-terms?q=misspelled+terms
+
+misspelled_terms = "halbiut sausadge stenolepsis chese bnoculars parnsip farmacy pape"
 
 
 def test_get_correct_terms_returns_success(client):
-    wrong_terms = "-"
-
-    response = client.get(f"/api/search/correct-terms/{wrong_terms}")
+    response = client.get(f"/api/search/correct-terms?q={misspelled_terms}")
 
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "application/json"
 
 
 def test_get_correct_terms_returns_valid_json(client):
-    wrong_terms = "halbiut sausadge stenolepsis chese bnoculars parnsip farmacy pape"
-
-    response = client.get(f"/api/search/correct-terms/{wrong_terms}")
+    response = client.get(f"/api/search/correct-terms?q={misspelled_terms}")
 
     response_body = response.json
 
@@ -28,4 +26,13 @@ def test_get_correct_terms_returns_valid_json(client):
         "paper",
     ]
 
-    assert response_body["entities"]["original_terms"] == wrong_terms
+    assert response_body["entities"]["original_terms"] == misspelled_terms
+
+
+# When query is empty
+def test_get_correct_terms_returns_400(client):
+    misspelled_terms = ""
+    response = client.get(f"/api/search/tokens?q={misspelled_terms}")
+
+    assert response.status_code == 400
+    assert response.text == "Error: the query params is empty."


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-1694

### What?
-[x] Support for query params on the endpoints /tokens and /correct-terms
-[x] Return error in case query term is empty

### Why?
This has been done
- to facilitate the construction of the query on the BE
- it makes sense to pass in potentially long query terms using query params.