### PR TITLE
HOTT-1882  Remove status 400 (to fix BE)

### DIFF
--- a/flaskr/__init__.py
+++ b/flaskr/__init__.py
@@ -34,9 +34,6 @@ def create_app(test_config=None):
     def tokens():
         search_query = request.args.get("q", default="", type=str)
 
-        if search_query == "":
-            return "Error: the query params is empty.", 400
-
         corrected_search_query = spell_corrector.correct(search_query)
 
         result = {}

--- a/tests/functional/test_get_tokens.py
+++ b/tests/functional/test_get_tokens.py
@@ -21,9 +21,8 @@ def test_get_tokens_returns_valid_json(client):
 
 
 # When query is empty
-def test_get_tokens_returns_400(client):
+def test_get_tokens_returns_200(client):
     query = ""
     response = client.get(f"/api/search/tokens?q={query}")
 
-    assert response.status_code == 400
-    assert response.text == "Error: the query params is empty."
+    assert response.status_code == 200


### PR DESCRIPTION
### What?

The empty query, is not a wrong query now, and it returns an empty list of tokens and status 200.

This prevents us to add more checks in the BE.

### Jira link

https://transformuk.atlassian.net/browse/HOTT-1882

### Why?
- to allow empty query q as a valid query
- to prevent status 500 on the BE
