### PR TITLE
HOTT-2323: Integrate alpine updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,7 +280,7 @@ workflows:
             branches:
               ignore:
                 - main
-                - /^dependabot\/.*/
+                - /^dependabot/(?!docker/).*/
       - build:
           name: build_dev
           context: trade-tariff
@@ -289,7 +289,7 @@ workflows:
             branches:
               ignore:
                 - main
-                - /^dependabot\/.*/
+                - /^dependabot/(?!docker/).*/
       - test:
           context: trade-tariff
           filters:
@@ -302,7 +302,7 @@ workflows:
             branches:
               ignore:
                 - main
-                - /^dependabot\/.*/
+                - /^dependabot/(?!docker/).*/
           requires:
             - build_dev
             - test
@@ -314,7 +314,7 @@ workflows:
               ignore:
                 - main
                 - /^hotfix\/.+/
-                - /^dependabot\/.*/
+                - /^dependabot/(?!docker/).*/
           requires:
             - deploy_development
       - build:


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2323
https://github.com/trade-tariff/trade-tariff-backend/pull/1060 - fully integrating docker dependabot branch
https://github.com/trade-tariff/trade-tariff-backend/pull/1062 - partially integrating ruby dependabot branch
https://github.com/trade-tariff/trade-tariff-backend/pull/1061 - partially integrating npm_and_yarn dependabot branch


### What?

I have added/removed/altered:

- [x] Excluded the dependabot/docker updates from the ignore filter when doing a build/deploy/release/smoke test to dev environment

### Why?

I am doing this because:

- This enables us to save time debugging docker os updates as part of our standard process
