### PR TITLE
HOTT-2813: Adds quote handling to search query parser

### DIFF
--- a/flaskr/quote_tokeniser.py
+++ b/flaskr/quote_tokeniser.py
@@ -1,0 +1,40 @@
+import re
+
+"""
+Converts an input query with surrounding single and double quotes and converts it
+to an array of token tuples that include the a token phrase and an instruction of whether
+to correct the tokens spelling.
+
+Example:
+    query = "this is a 'test query'"
+    tokeniser = SpellingTokeniser()
+    tokens = tokeniser.tokenise(query)
+    print(tokens)
+    # [('this', True), ('is', True), ('a', True), ('test query', False)]
+
+
+Parameters:
+    search_term (str): The search term to be tokenised.
+
+Returns:
+    list: A list of tuples containing the token and a boolean value indicating whether the token should be corrected.
+"""
+
+class QuoteTokeniser:
+    PATTERN = re.compile(r'((?:"(?:\\.|[^\\"])*")|(?:\'(?:\\.|[^\\\'])*\')|\S+)')
+
+    @staticmethod
+    def tokenise(search_term):
+        if search_term is None or search_term == '':
+            return []
+
+        terms = []
+        for match in QuoteTokeniser.PATTERN.finditer(search_term):
+            term = match.group(0)
+            if term.startswith('"') and term.endswith('"'):
+                terms.append((term, True))
+            elif term.startswith("'") and term.endswith("'"):
+                terms.append((term, True))
+            else:
+                terms.append((term, False))
+        return terms

--- a/flaskr/quote_tokeniser.py
+++ b/flaskr/quote_tokeniser.py
@@ -20,6 +20,7 @@ Returns:
     list: A list of tuples containing the token and a boolean value indicating whether the token should be corrected.
 """
 
+
 class QuoteTokeniser:
     PATTERN = re.compile(r'((?:"(?:\\.|[^\\"])*")|(?:\'(?:\\.|[^\\\'])*\')|\S+)')
 
@@ -29,6 +30,7 @@ class QuoteTokeniser:
             return []
 
         terms = []
+
         for match in QuoteTokeniser.PATTERN.finditer(search_term):
             term = match.group(0)
             if term.startswith('"') and term.endswith('"'):

--- a/flaskr/quote_tokeniser.py
+++ b/flaskr/quote_tokeniser.py
@@ -1,13 +1,13 @@
 import re
 
 """
-Converts an input query with surrounding single and double quotes and converts it
-to an array of token tuples that include the a token phrase and an instruction of whether
-to correct the tokens spelling.
+Converts an input query with surrounding single and double quotes and produces
+an array of token tuples that include token phrase and an instruction of whether
+the tokens are within single or double quotes
 
 Example:
     query = "this is a 'test query'"
-    tokeniser = SpellingTokeniser()
+    tokeniser = QuoteTokeniser()
     tokens = tokeniser.tokenise(query)
     print(tokens)
     # [('this', True), ('is', True), ('a', True), ('test query', False)]

--- a/flaskr/synonym_file_handler.py
+++ b/flaskr/synonym_file_handler.py
@@ -50,6 +50,8 @@ class SynonymFileHandler:
     def parse_file(self):
         if self.filename:
             filename = self.filename
+        elif os.getenv("FLASK_ENV") == "test":
+            filename = SynonymFileHandler.SYNONYM_FALLBACK_FILEPATH
         elif os.path.exists(SynonymFileHandler.SYNONYM_FILEPATH):
             filename = SynonymFileHandler.SYNONYM_FILEPATH
         else:

--- a/flaskr/tokenizer.py
+++ b/flaskr/tokenizer.py
@@ -71,9 +71,8 @@ class Tokenizer:
 
         return clean_noun_chunks
 
-
     def _handle_excluded_token(self, token):
-        should_lemma = not token.text in stemming_exclusion_handler.excluded_terms
+        should_lemma = token.text not in stemming_exclusion_handler.excluded_terms
 
         if should_lemma:
             return token.lemma_
@@ -87,8 +86,6 @@ class Tokenizer:
         dirty_token = token.is_stop or token.is_punct
 
         return not dirty_token
-
-
 
     def _record_token_information(self, tokens, doc):
         all_tokens = {}

--- a/flaskr/tokenizer.py
+++ b/flaskr/tokenizer.py
@@ -1,6 +1,7 @@
 import spacy
 import os
 from flaskr.stemming_exclusion_file_handler import StemmingExclusionFileHandler
+from flaskr.quote_tokeniser import QuoteTokeniser
 
 stemming_exclusion_handler = StemmingExclusionFileHandler()
 stemming_exclusion_handler.load()
@@ -8,26 +9,100 @@ nlp = spacy.load(os.environ["SPACY_DICTIONARY"])
 
 
 class Tokenizer:
-    def __init__(self):
-        pass
+    def __init__(self, search_query):
+        self._search_query = search_query
+        self._quoted_tokens = QuoteTokeniser.tokenise(search_query)
+        self._debug_tokens = os.getenv("DEBUG_TOKENS") == "true"
 
-    def get_tokens(self, search_query):
-        doc = nlp(search_query)
+    def get_tokens(self):
+        quoted_tokens = []
+        unquoted_tokens = []
+        quoted_search_query = ""
+        unquoted_search_query = ""
 
-        all_tokens = [self._handle_excluded_token(token) for token in doc]
+        for token, quoted in self._quoted_tokens:
+            if quoted:
+                quoted_search_query += token + " "
+            else:
+                unquoted_search_query += token + " "
+
+        doc = nlp(unquoted_search_query)
+
+        cleaned_chunks = self._clean_chunks(doc)
+        cleaned_tokens = self._clean_tokens(doc)
+
+        nouns = [self._handle_excluded_token(token) for token in cleaned_tokens if token.pos_ == "NOUN"]
+        verbs = [self._handle_excluded_token(token) for token in cleaned_tokens if token.pos_ == "VERB"]
+        adjectives = [self._handle_excluded_token(token) for token in cleaned_tokens if token.pos_ == "ADJ"]
+
+        if quoted_search_query:
+            quoted_search_query = quoted_search_query.strip()
+            quoted_tokens += quoted_search_query.split(" ")
+
+        if unquoted_search_query:
+            unquoted_search_query = unquoted_search_query.strip()
+            unquoted_tokens += unquoted_search_query.split(" ")
 
         tokens = {
-            "all": all_tokens,
-            "nouns": [self._handle_excluded_token(token) for token in doc if token.pos_ == "NOUN"],
-            "verbs": [self._handle_excluded_token(token) for token in doc if token.pos_ == "VERB"],
-            "adjectives": [self._handle_excluded_token(token) for token in doc if token.pos_ == "ADJ"],
-            "noun_chunks": [chunk.text for chunk in doc.noun_chunks],
+            "quoted": quoted_tokens,
+            "unquoted": unquoted_tokens,
+            "nouns": nouns,
+            "verbs": verbs,
+            "adjectives": adjectives,
+            "noun_chunks": cleaned_chunks,
         }
+
+        if self._debug_tokens:
+            self._record_token_information(tokens, doc)
 
         return tokens
 
+    def _clean_chunks(self, doc):
+        noun_chunks = list(doc.noun_chunks)
+        clean_noun_chunks = []
+
+        for chunk in noun_chunks:
+            clean_tokens = [token for token in chunk if not token.is_punct]
+            if clean_tokens:
+                clean_text = ' '.join([token.text for token in clean_tokens])
+            else:
+                clean_text = chunk.text
+            clean_noun_chunks.append(clean_text)
+
+        return clean_noun_chunks
+
+
     def _handle_excluded_token(self, token):
-        if token.text in stemming_exclusion_handler.excluded_terms:
-            return token.text
-        else:
+        should_lemma = not token.text in stemming_exclusion_handler.excluded_terms
+
+        if should_lemma:
             return token.lemma_
+        else:
+            return token.text
+
+    def _clean_tokens(self, doc):
+        return [token for token in doc if self._is_clean_token(token)]
+
+    def _is_clean_token(self, token):
+        dirty_token = token.is_stop or token.is_punct
+
+        return not dirty_token
+
+
+
+    def _record_token_information(self, tokens, doc):
+        all_tokens = {}
+
+        for token in doc:
+            all_tokens[token.text] = {
+                "lemma": token.lemma_,
+                "pos": token.pos_,
+                "tag": token.tag_,
+                "dep": token.dep_,
+                "shape": token.shape_,
+                "is_alpha": token.is_alpha,
+                "is_stop": token.is_stop,
+                "is_punct": token.is_punct,
+            }
+
+        tokens["all"] = all_tokens

--- a/tests/functional/test_get_healthcheck.py
+++ b/tests/functional/test_get_healthcheck.py
@@ -1,6 +1,3 @@
-# Test GET /healthcheck
-
-
 def test_get_healthcheck_returns_success(client):
     response = client.get("/api/search/healthcheck")
 
@@ -20,3 +17,4 @@ def test_get_healthcheck_returns_valid_json(client):
     assert response_body["healthy"]
     assert isinstance(response_body["using_spelling_fallback"], bool)
     assert isinstance(response_body["using_synonym_fallback"], bool)
+    assert isinstance(response_body["using_stemming_exclusion_fallback"], bool)

--- a/tests/functional/test_get_tokens.py
+++ b/tests/functional/test_get_tokens.py
@@ -25,17 +25,18 @@ class ValidTokens(object):
 def test_stemmable_tokens_are_stemmed_returns_success(client):
     with ValidTokens(client, "/api/search/tokens?q=whiting") as r:
         actual = r.json
+
         expected = {
             'corrected_search_query': 'whiting',
             'expanded_search_query': 'merling whiting',
             'original_search_query': 'whiting',
             'tokens': {
                 'adjectives': [],
-                'noun_chunks': [],
-                'nouns': [],
+                'noun_chunks': ['whiting'],
+                'nouns': ['whiting'],
                 'quoted': [],
                 'unquoted': ['merling', 'whiting'],
-                'verbs': ['merling', 'whiting'],
+                'verbs': ['merle'],
             },
         }
 

--- a/tests/functional/test_get_tokens.py
+++ b/tests/functional/test_get_tokens.py
@@ -1,6 +1,3 @@
-# Test GET /tokens?q=query+terms
-
-
 class ValidTokens(object):
     def __init__(self, client, path):
         self._client = client
@@ -13,7 +10,7 @@ class ValidTokens(object):
         assert response.status_code == 200
         assert response.headers["Content-Type"] == "application/json"
 
-        for token_type in ["all", "adjectives", "nouns", "verbs", "noun_chunks"]:
+        for token_type in ["adjectives", "nouns", "verbs", "noun_chunks"]:
             assert token_type in response_body["tokens"]
 
         for search_query in ["original_search_query", "corrected_search_query"]:
@@ -34,10 +31,11 @@ def test_stemmable_tokens_are_stemmed_returns_success(client):
             'original_search_query': 'whiting',
             'tokens': {
                 'adjectives': [],
-                'all': ['merle', 'whiting'],
-                'noun_chunks': ['whiting'],
-                'nouns': ['whiting'],
-                'verbs': ['merle'],
+                'noun_chunks': [],
+                'nouns': [],
+                'quoted': [],
+                'unquoted': ['merling', 'whiting'],
+                'verbs': ['merling', 'whiting'],
             },
         }
 
@@ -83,3 +81,23 @@ def test_get_tokens_spelling_off_corrects_spelling_returns_valid_json(client):
 def test_get_tokens_empty_query_returns_200(client):
     with ValidTokens(client, "/api/search/tokens?q="):
         pass
+
+
+def test_get_tokens_single_quotes_prevents_spelling_correction_returns_200(client):
+    with ValidTokens(client, "/api/search/tokens?q='paracetamol'+is+a+great+thing+to+%22tested%22&spell=1") as r:
+        actual = r.json
+        expected = {
+            'corrected_search_query': '\'paracetamol\' iso a great thing two "tested"',
+            'expanded_search_query': '\'paracetamol\' iso a great thing two "tested"',
+            'original_search_query': '\'paracetamol\' is a great thing to "tested"',
+            'tokens': {
+                'adjectives': ['great'],
+                'noun_chunks': ['a great thing'],
+                'nouns': ['thing'],
+                'quoted': ["'paracetamol'", '"tested"'],
+                'unquoted': ['iso', 'a', 'great', 'thing', 'two'],
+                'verbs': ['iso'],
+            },
+        }
+
+        assert actual == expected

--- a/tests/unit/test_quote_tokeniser.py
+++ b/tests/unit/test_quote_tokeniser.py
@@ -15,6 +15,7 @@ def test_tokenise_single_quotes():
 
     assert actual == expected
 
+
 def test_tokenise_double_quotes():
     query = 'this is a "test query"'
     tokeniser = QuoteTokeniser()
@@ -27,6 +28,7 @@ def test_tokenise_double_quotes():
     actual = tokeniser.tokenise(query)
 
     assert actual == expected
+
 
 def test_tokenise_mixed_quotes():
     query = 'this is a "test query" and this is a \'test query\''
@@ -46,6 +48,7 @@ def test_tokenise_mixed_quotes():
 
     assert actual == expected
 
+
 def test_tokenise_empty_string():
     query = ''
     tokeniser = QuoteTokeniser()
@@ -54,6 +57,7 @@ def test_tokenise_empty_string():
 
     assert actual == expected
 
+
 def test_tokenise_none():
     query = None
     tokeniser = QuoteTokeniser()
@@ -61,6 +65,7 @@ def test_tokenise_none():
     actual = tokeniser.tokenise(query)
 
     assert actual == expected
+
 
 def test_tokenise_incomplete_double_quotes():
     query = 'this is a "test query'
@@ -75,6 +80,7 @@ def test_tokenise_incomplete_double_quotes():
     actual = tokeniser.tokenise(query)
 
     assert actual == expected
+
 
 def test_tokenise_incomplete_single_quotes():
     query = 'this is a \'test query'

--- a/tests/unit/test_quote_tokeniser.py
+++ b/tests/unit/test_quote_tokeniser.py
@@ -1,0 +1,91 @@
+from flaskr.quote_tokeniser import QuoteTokeniser
+
+
+def test_tokenise_single_quotes():
+    query = "this is a 'test query'"
+    tokeniser = QuoteTokeniser()
+    expected = [
+        ('this', False),
+        ('is', False),
+        ('a', False),
+        ('\'test query\'', True),
+    ]
+
+    actual = tokeniser.tokenise(query)
+
+    assert actual == expected
+
+def test_tokenise_double_quotes():
+    query = 'this is a "test query"'
+    tokeniser = QuoteTokeniser()
+    expected = [
+        ('this', False),
+        ('is', False),
+        ('a', False),
+        ('"test query"', True),
+    ]
+    actual = tokeniser.tokenise(query)
+
+    assert actual == expected
+
+def test_tokenise_mixed_quotes():
+    query = 'this is a "test query" and this is a \'test query\''
+    tokeniser = QuoteTokeniser()
+    expected = [
+        ('this', False),
+        ('is', False),
+        ('a', False),
+        ('"test query"', True),
+        ('and', False),
+        ('this', False),
+        ('is', False),
+        ('a', False),
+        ('\'test query\'', True),
+    ]
+    actual = tokeniser.tokenise(query)
+
+    assert actual == expected
+
+def test_tokenise_empty_string():
+    query = ''
+    tokeniser = QuoteTokeniser()
+    expected = []
+    actual = tokeniser.tokenise(query)
+
+    assert actual == expected
+
+def test_tokenise_none():
+    query = None
+    tokeniser = QuoteTokeniser()
+    expected = []
+    actual = tokeniser.tokenise(query)
+
+    assert actual == expected
+
+def test_tokenise_incomplete_double_quotes():
+    query = 'this is a "test query'
+    tokeniser = QuoteTokeniser()
+    expected = [
+        ('this', False),
+        ('is', False),
+        ('a', False),
+        ('"test', False),
+        ('query', False),
+    ]
+    actual = tokeniser.tokenise(query)
+
+    assert actual == expected
+
+def test_tokenise_incomplete_single_quotes():
+    query = 'this is a \'test query'
+    tokeniser = QuoteTokeniser()
+    expected = [
+        ('this', False),
+        ('is', False),
+        ('a', False),
+        ('\'test', False),
+        ('query', False),
+    ]
+    actual = tokeniser.tokenise(query)
+
+    assert actual == expected

--- a/tests/unit/test_spelling_corrector.py
+++ b/tests/unit/test_spelling_corrector.py
@@ -12,6 +12,26 @@ def test_spelling_corrector_correct():
     )
 
 
+def test_spelling_corrector_with_single_quotes():
+    spelling_corrector = SpellingCorrector()
+    search_query = "'halbiut' sausadge stenolepsis chese bnoculars parnsip farmacy papre"
+    corrected_search_query = spelling_corrector.correct(search_query)
+
+    assert (
+        corrected_search_query
+        == "'halbiut' sausage stenolepis cheese binoculars parsnip pharmacy paper"
+    )
+
+def test_spelling_corrector_with_double_quotes():
+    spelling_corrector = SpellingCorrector()
+    search_query = '"halbiut" sausadge stenolepsis chese bnoculars parnsip farmacy papre'
+    corrected_search_query = spelling_corrector.correct(search_query)
+
+    assert (
+        corrected_search_query
+        == '"halbiut" sausage stenolepis cheese binoculars parsnip pharmacy paper'
+    )
+
 def test_spelling_corrector_synonym_not_corrected():
     spelling_corrector = SpellingCorrector()
     search_query = "acamol"

--- a/tests/unit/test_spelling_corrector.py
+++ b/tests/unit/test_spelling_corrector.py
@@ -22,6 +22,7 @@ def test_spelling_corrector_with_single_quotes():
         == "'halbiut' sausage stenolepis cheese binoculars parsnip pharmacy paper"
     )
 
+
 def test_spelling_corrector_with_double_quotes():
     spelling_corrector = SpellingCorrector()
     search_query = '"halbiut" sausadge stenolepsis chese bnoculars parnsip farmacy papre'
@@ -31,6 +32,7 @@ def test_spelling_corrector_with_double_quotes():
         corrected_search_query
         == '"halbiut" sausage stenolepis cheese binoculars parsnip pharmacy paper'
     )
+
 
 def test_spelling_corrector_synonym_not_corrected():
     spelling_corrector = SpellingCorrector()

--- a/tests/unit/test_tokenizer.py
+++ b/tests/unit/test_tokenizer.py
@@ -25,11 +25,12 @@ def test_tokenizer_get_tokens(app):
             'dog',
         ],
         'verbs': ['jump'],
-        'adjectives' : ['brown'],
+        'adjectives': ['brown'],
         'noun_chunks': ['The brown fox', 'the dog'],
     }
 
     assert tokens == expected
+
 
 def test_stem_excluded_token(app):
     search_query = "clothes and clothing"

--- a/tests/unit/test_tokenizer.py
+++ b/tests/unit/test_tokenizer.py
@@ -2,9 +2,38 @@ from flaskr.tokenizer import Tokenizer
 
 
 def test_tokenizer_get_tokens(app):
-    tokenizer = Tokenizer()
-    search_query = "tall man"
-    tokens = tokenizer.get_tokens(search_query)
+    search_query = "The 'quick' brown fox jumped over the \"lazy\" dog."
+    tokenizer = Tokenizer(search_query)
+    tokens = tokenizer.get_tokens()
 
-    for token_type in ["all", "adjectives", "nouns", "verbs"]:
-        assert token_type in tokens
+    expected = {
+        'quoted': [
+            "'quick'",
+            '"lazy"'
+        ],
+        'unquoted': [
+            'The',
+            'brown',
+            'fox',
+            'jumped',
+            'over',
+            'the',
+            'dog.',
+        ],
+        'nouns': [
+            'fox',
+            'dog',
+        ],
+        'verbs': ['jump'],
+        'adjectives' : ['brown'],
+        'noun_chunks': ['The brown fox', 'the dog'],
+    }
+
+    assert tokens == expected
+
+def test_stem_excluded_token(app):
+    search_query = "clothes and clothing"
+    tokenizer = Tokenizer(search_query)
+    tokens = tokenizer.get_tokens()
+
+    assert "clothes" in tokens["nouns"]


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2813

### What?

I have added/removed/altered:

- [x] Adds a quote tokeniser that will be used by spelling a lemma filters
- [x] Update tokenizer to handle quoted tokens
- [x] Update spelling correct to use quote tokenizer
- [x] Prevent using s3 file in test mode
- [x] Reflect the updated api for quoted tokens
- [x] Reflect changes to flask endpoints in tests

### Why?

I am doing this because:

- This is required to support double and single quotes that might exist over an arbitrary number of words
- This is actually something requested by HMRC
