### PR TITLE
HOTT-3653: Add Terraform for Search Query Parser

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+---
+files: (^terraform\/\S+)|(.pre\-commit\-config.yaml)|(.circleci\/\S+)
+repos:
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.81.0
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate
+      - id: terraform_tflint
+      - id: terraform_tfsec
+      - id: terraform_docs
+        args:
+          - --hook-config=--add-to-existing-file=true
+          - --hook-config=--path-to-file=README.md
+          - --hook-config=--create-file-if-not-exist=true
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,42 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+!config_*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# nix things
+.envrc
+.direnv/
+
+# os nonsense
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+.Directory
+.go

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.67.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:P43vwcDPG99x5WBbmqwUPgfJrfXf6/ucAIbGlRb7k1w=",
+    "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
+    "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
+    "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
+    "zh:4a002990b9f4d6d225d82cb2fb8805789ffef791999ee5d9cb1fef579aeff8f1",
+    "zh:559a2b5ace06b878c6de3ecf19b94fbae3512562f7a51e930674b16c2f606e29",
+    "zh:6a07da13b86b9753b95d4d8218f6dae874cf34699bca1470d6effbb4dee7f4b7",
+    "zh:768b3bfd126c3b77dc975c7c0e5db3207e4f9997cf41aa3385c63206242ba043",
+    "zh:7be5177e698d4b547083cc738b977742d70ed68487ce6f49ecd0c94dbf9d1362",
+    "zh:8b562a818915fb0d85959257095251a05c76f3467caa3ba95c583ba5fe043f9b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c385d03a958b54e2afd5279cd8c7cbdd2d6ca5c7d6a333e61092331f38af7cf",
+    "zh:b3ca45f2821a89af417787df8289cb4314b273d29555ad3b2a5ab98bb4816b3b",
+    "zh:da3c317f1db2469615ab40aa6baba63b5643bae7110ff855277a1fb9d8eb4f2c",
+    "zh:dc6430622a8dc5cdab359a8704aec81d3825ea1d305bbb3bbd032b1c6adfae0c",
+    "zh:fac0d2ddeadf9ec53da87922f666e1e73a603a611c57bcbc4b86ac2821619b1d",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.5.1"
+  constraints = ">= 3.4.3"
+  hashes = [
+    "h1:sZ7MTSD4FLekNN2wSNFGpM+5slfvpm5A/NLVZiB7CO0=",
+    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
+    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
+    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
+    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
+    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
+    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
+    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
+    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
+    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
+    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+  ]
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,55 @@
+# trade-tariff-search-query-parser terraform
+
+Terraform to deploy the service into AWS.
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.4 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.67.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.6.1 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_policy.buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_lb_target_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
+| [aws_s3_bucket.spelling_corrector](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
+| [aws_s3_bucket.synonym_packages](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
+| [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
+| [aws_ssm_parameter.ecr_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+| [aws_subnets.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
+| [aws_vpc.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU units to use. | `number` | n/a | yes |
+| <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Image tag to use. | `string` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment. | `string` | n/a | yes |
+| <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | Largest number of tasks the service can scale-out to. | `number` | n/a | yes |
+| <a name="input_memory"></a> [memory](#input\_memory) | Memory to allocate in MB. Powers of 2 only. | `number` | n/a | yes |
+| <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | Smallest number of tasks the service can scale-in to. | `number` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | AWS region to use. | `string` | n/a | yes |
+| <a name="input_service_count"></a> [service\_count](#input\_service\_count) | Number of services to use. | `number` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/terraform/backends/development.tfbackend
+++ b/terraform/backends/development.tfbackend
@@ -1,0 +1,4 @@
+bucket  = "terraform-state-development-844815912454"
+key     = "tariff-duty-calculator.tfstate"
+region  = "eu-west-2"
+encrypt = true

--- a/terraform/backends/development.tfbackend
+++ b/terraform/backends/development.tfbackend
@@ -1,4 +1,4 @@
 bucket  = "terraform-state-development-844815912454"
-key     = "tariff-duty-calculator.tfstate"
+key     = "tariff-search-query-parser.tfstate"
 region  = "eu-west-2"
 encrypt = true

--- a/terraform/config_development.tfvars
+++ b/terraform/config_development.tfvars
@@ -1,0 +1,8 @@
+region        = "eu-west-2"
+environment   = "development"
+base_domain   = "transformtariff.co.uk"
+cpu           = 512
+memory        = 1024
+service_count = 2
+min_capacity  = 1
+max_capacity  = 3

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,0 +1,36 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_vpc" "vpc" {
+  tags = { Name = "trade_tariff_${var.environment}_vpc" }
+}
+
+data "aws_subnets" "private" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.vpc.id]
+  }
+
+  tags = {
+    Name = "*private*"
+  }
+}
+
+data "aws_lb_target_group" "this" {
+  name = "trade-tariff-sqp-tg-${var.environment}"
+}
+
+data "aws_security_group" "this" {
+  name = "trade-tariff-ecs-security-group-${var.environment}"
+}
+
+data "aws_ssm_parameter" "ecr_url" {
+  name = "/${var.environment}/SEARCH_QUERY_PARSER_ECR_URL"
+}
+
+data "aws_s3_bucket" "spelling_corrector" {
+  bucket = "trade-tariff-search-configration-${local.account_id}"
+}
+
+data "aws_s3_bucket" "synonym_packages" {
+  bucket = "trade-tariff-opensearch-packages-${local.account_id}"
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,18 @@
+data "aws_iam_policy_document" "buckets" {
+  statement {
+    effect  = "Allow"
+    actions = ["s3:GetObject"]
+    resources = [
+      data.aws_s3_bucket.synonym_packages.arn,
+      "${data.aws_s3_bucket.synonym_packages.arn}/config/opensearch/stemming_exclusions_all.txt",
+      "${data.aws_s3_bucket.synonym_packages.arn}/config/opensearch/synonyms_all.txt",
+      data.aws_s3_bucket.spelling_corrector.arn,
+      "${data.aws_s3_bucket.spelling_corrector.arn}/spelling-corrector/spelling-model.txt",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "buckets" {
+  name   = "${local.service}-execution-role-buckets-policy"
+  policy = data.aws_iam_policy_document.buckets.json
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  service    = "search-query-parser"
+  account_id = data.aws_caller_identity.current.account_id
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,66 @@
+module "service" {
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.6.1"
+
+  environment = var.environment
+  region      = var.region
+
+  service_name  = local.service
+  service_count = var.service_count
+
+  cluster_name              = "trade-tariff-cluster-${var.environment}"
+  subnet_ids                = data.aws_subnets.private.ids
+  security_groups           = [data.aws_security_group.this.id]
+  target_group_arn          = data.aws_lb_target_group.this.arn
+  cloudwatch_log_group_name = "platform-logs-${var.environment}"
+
+  min_capacity = var.min_capacity
+  max_capacity = var.max_capacity
+
+  docker_image = data.aws_ssm_parameter.ecr_url.value
+  docker_tag   = var.docker_tag
+  skip_destroy = true
+
+  container_port = 8080
+
+  cpu    = var.cpu
+  memory = var.memory
+
+  execution_role_policy_arns = [
+    aws_iam_policy.buckets.arn
+  ]
+
+  service_environment_config = [
+    {
+      name  = "EXPAND_EQUIVALENT_SYNONYMS"
+      value = "true"
+    },
+    {
+      name  = "EXPAND_EXPLICIT_SYNONYMS"
+      value = "true"
+    },
+    {
+      name  = "FLASK_APP"
+      value = "flaskr"
+    },
+    {
+      name = "FLASK_ENV"
+      name = var.environment
+    },
+    {
+      name  = "MAXIMUM_WORD_LENGTH"
+      value = 15
+    },
+    {
+      name  = "PACKAGE_BUCKET_NAME"
+      value = data.aws_s3_bucket.synonym_packages.bucket
+    },
+    {
+      name  = "SPACY_DICTIONARY"
+      value = "en_core_web_md"
+    },
+    {
+      name  = "SPELLING_CORRECTOR_BUCKET_NAME"
+      value = data.aws_s3_bucket.spelling_corrector.bucket
+    }
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -32,7 +32,7 @@ module "service" {
   service_environment_config = [
     {
       name  = "EXPAND_EQUIVALENT_SYNONYMS"
-      value = "true"
+      value = "false"
     },
     {
       name  = "EXPAND_EXPLICIT_SYNONYMS"
@@ -44,7 +44,7 @@ module "service" {
     },
     {
       name = "FLASK_ENV"
-      name = var.environment
+      name = "production"
     },
     {
       name  = "MAXIMUM_WORD_LENGTH"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,39 @@
+variable "environment" {
+  description = "Deployment environment."
+  type        = string
+}
+
+variable "region" {
+  description = "AWS region to use."
+  type        = string
+}
+
+variable "docker_tag" {
+  description = "Image tag to use."
+  type        = string
+}
+
+variable "service_count" {
+  description = "Number of services to use."
+  type        = number
+}
+
+variable "min_capacity" {
+  description = "Smallest number of tasks the service can scale-in to."
+  type        = number
+}
+
+variable "max_capacity" {
+  description = "Largest number of tasks the service can scale-out to."
+  type        = number
+}
+
+variable "cpu" {
+  description = "CPU units to use."
+  type        = number
+}
+
+variable "memory" {
+  description = "Memory to allocate in MB. Powers of 2 only."
+  type        = number
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.4"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4"
+    }
+  }
+
+  backend "s3" {}
+}
+
+provider "aws" {}


### PR DESCRIPTION
### Jira link

[HOTT-3653](https://transformuk.atlassian.net/browse/HOTT-3653)

### What?

I have added/removed/altered:

- Added the Terraform for the search query parser.

### Why?

I am doing this because:

- This is required to control the service on ECS.