### PR TITLE
BAU: Quick Fix IAM Policy

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -3,7 +3,7 @@ data "aws_iam_policy_document" "buckets" {
     effect = "Allow"
     actions = [
       "s3:GetObject",
-      "s3:ListObject"
+      "s3:ListBucket"
     ]
     resources = [
       data.aws_s3_bucket.synonym_packages.arn,


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Updated the IAM policy for bucket access.

### Why?

I am doing this because:

- `s3:ListObject` isn't an action, it's `s3:ListBucket`
