### PR TITLE
HOTT-3673: Bump module, add private dns namespace

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -19,7 +19,7 @@ Terraform to deploy the service into AWS.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.6.1 |
+| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.7.0 |
 
 ## Resources
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 module "service" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.6.1"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.7.0"
 
   environment = var.environment
   region      = var.region
@@ -28,6 +28,8 @@ module "service" {
   task_role_policy_arns = [
     aws_iam_policy.buckets.arn
   ]
+
+  private_dns_namespace = "tariff.internal"
 
   service_environment_config = [
     {


### PR DESCRIPTION
### Jira link

[HOTT-3673](https://transformuk.atlassian.net/browse/HOTT-3673)

### What?

I have added/removed/altered:

- Bumped the ECS service module to 1.7.0

### Why?

I am doing this because:

- This will create the service discovery service and map a private route on `search-query-parser.tariff.internal`.