### PR TITLE
HOTT-3895 - Rollout blue-green deployment

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -19,7 +19,7 @@ Terraform to deploy the service into AWS.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.7.0 |
+| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.11.3 |
 
 ## Resources
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,8 +1,7 @@
 module "service" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.7.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.11.3"
 
-  environment = var.environment
-  region      = var.region
+  region = var.region
 
   service_name  = local.service
   service_count = var.service_count


### PR DESCRIPTION
### Jira link

HOTT-3895

### What?

- Updated ECS service module to v1.11.3

### Why?

I am doing this because:

- To rollout blue-green deployment
