### PR TITLE
Revert "Bump urllib3 from 1.26.15 to 2.0.5"

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -38,5 +38,5 @@ thinc==8.2.1
 tqdm==4.65.0
 typer==0.7.0
 typing_extensions==4.5.0
-urllib3==2.0.5
+urllib3==1.26.15
 wasabi==1.1.2


### PR DESCRIPTION
Reverts trade-tariff/trade-tariff-search-query-parser#270