### PR TITLE
BAU: Fix image-name parameter in production release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,7 +309,7 @@ workflows:
 
       - tariff/create-production-release:
           context: trade-tariff
-          image-name: tariff-search-query-parser
+          image-name: tariff-search-query-parser-production
           requires:
             - promote-to-production?
           <<: *filter-main


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Fixed broken `image-name` parameter in release job

### Why?

I am doing this because:

- It's wrong and blocking releases
