### PR TITLE
HOTT-5096 Test dependabot PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ filter-not-main: &filter-not-main
     branches:
       ignore:
         - main
-        - /^dependabot/(?!docker/).*/
         - /^hotfix\/.+/
 
 filter-main: &filter-main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,14 +236,20 @@ workflows:
           ssm_parameter: "/development/SEARCH_QUERY_PARSER_ECR_URL"
           <<: *filter-not-main
 
+      - confirm-deploy-for-qa?:
+          type: approval
+          requires:
+            - test
+            - plan-terraform-dev
+            - build-and-push-dev
+          <<: *filter-not-main
+
       - apply-terraform:
           name: apply-terraform-dev
           context: trade-tariff-terraform-aws-development
           environment: development
           requires:
-            - test
-            - plan-terraform-dev
-            - build-and-push-dev
+            - confirm-deploy-for-qa?
           <<: *filter-not-main
 
       - tariff/smoketests:


### PR DESCRIPTION
### Jira link

HOTT-5096

### What?

I have added/removed/altered:

- [x] Added in testing for dependabot PRs

### Why?

I am doing this because:

- currently dependabot PRs can get all the way out to production without every running the test suite

### Deployment risks (optional)

- Low tightens CI standards
