### PR TITLE
BAU: Fixes deployments notifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,9 @@ jobs:
         type: string
     steps:
       - checkout
+      - run:
+          name: Add curl
+          command: apk --no-cache add curl jq
       - attach_workspace:
           at: .
       - terraform/init:
@@ -172,9 +175,6 @@ jobs:
           backend_config_file: backends/<< parameters.environment >>.tfbackend
           var_file: config_<< parameters.environment >>.tfvars
           lock-timeout: 5m
-      - run:
-          name: Add curl
-          command: apk --no-cache add curl jq
       - slack/notify:
           channel: deployments
           event: fail


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Fixes deployment notifications

### Why?

I am doing this because:

- The event to trigger a failure bypasses the usual flow which would have installed curl and jq in the alpine image. This means we don't see failed deployment notifications. Hoisting the installation fixes this
